### PR TITLE
feat: upgrade from Node.js 20 to Node.js 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -72,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Download build artifacts
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install
         run: yarn install
       - name: Get current CDKTF version

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-node.yml
+++ b/.github/workflows/upgrade-node.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install
         run: yarn install
       - name: Get current Node.js version

--- a/.github/workflows/upgrade-terraform.yml
+++ b/.github/workflows/upgrade-terraform.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
-          node-version: 20.9.0
+          node-version: 24.0.0
       - name: Install
         run: yarn install
       - name: Get current Terraform version

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^20",
+      "version": "^24",
       "type": "build"
     },
     {

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@
 name: terraform-cdk-action
 description: The Terraform CDK GitHub Action allows you to run CDKTF as part of your CI/CD workflow.
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 author: HashiCorp, Inc.
 branding:

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@action-validator/core": "^0.6.0",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^29",
-    "@types/node": "^20",
+    "@types/node": "^24",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "@vercel/ncc": "^0.38.4",
@@ -69,7 +69,7 @@
     "@hashicorp/js-releases": "^1.7.0"
   },
   "engines": {
-    "node": ">= 20.9.0"
+    "node": ">= 24.0.0"
   },
   "main": "lib/index.js",
   "license": "MPL-2.0",

--- a/projenrc/index.ts
+++ b/projenrc/index.ts
@@ -110,7 +110,7 @@ export class TerraformCdkActionProject extends GitHubActionTypeScriptProject {
           {}
         ),
         runs: {
-          using: RunsUsing.NODE_20,
+          using: "node24" as RunsUsing,
           main: "dist/index.js",
         },
       },
@@ -129,7 +129,7 @@ export class TerraformCdkActionProject extends GitHubActionTypeScriptProject {
         "@action-validator/cli",
       ],
       peerDeps: [`constructs@^${constructsVersion}`],
-      minNodeVersion: "20.9.0",
+      minNodeVersion: "24.0.0",
     });
 
     new Automerge(this);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,12 +1075,12 @@
   dependencies:
     undici-types "~7.12.0"
 
-"@types/node@^20":
-  version "20.19.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.17.tgz#41b52697373aef8a43b3b92f33b43f329b2d674b"
-  integrity sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==
+"@types/node@^24":
+  version "24.12.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
+  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.16.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -5541,15 +5541,15 @@ unbox-primitive@^1.1.0:
     has-symbols "^1.1.0"
     which-boxed-primitive "^1.1.1"
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
 undici-types@~7.12.0:
   version "7.12.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
   integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
+
+undici-types@~7.16.0:
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 undici@^5.25.4, undici@^5.28.5:
   version "5.29.0"


### PR DESCRIPTION
## Summary

- Updates `action.yml` runs to `node24`
- Updates `minNodeVersion` to `24.0.0` in `projenrc/index.ts`, propagating to all workflow `node-version` fields
- Addresses the Node.js 20 deprecation warning from GitHub Actions (forced to Node.js 24 starting June 2nd, 2026)

## Test plan

- [ ] Build workflow passes
- [ ] Action runs correctly on Node.js 24