### PR TITLE
chore!: change default Terraform version to 1.15.7

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -30,7 +30,7 @@ const inputs = {
   },
   terraformVersion: {
     description: "The version of Terraform to use",
-    default: "1.13.3",
+    default: "1.15.7",
     required: false,
     type: "string",
   },

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The Terraform CDK GitHub Action allows you to run CDKTF as part of your CI/CD wo
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `cdktfVersion` | <p>The version of CDKTF to use</p> | `false` | `0.21.0` |
-| `terraformVersion` | <p>The version of Terraform to use</p> | `false` | `1.13.3` |
+| `terraformVersion` | <p>The version of Terraform to use</p> | `false` | `1.15.7` |
 | `workingDirectory` | <p>The directory to use for the project</p> | `false` | `./` |
 | `mode` | <p>What action to take: <code>synth-only</code> runs only the synthesis, <code>plan-only</code> only runs a plan, <code>auto-approve-apply</code> runs a plan and then performs an apply, <code>auto-approve-destroy</code> runs a plan and then performs a destroy</p> | `true` | `""` |
 | `stackName` | <p>The stack to run / plan, only required when the mode is <code>plan-only</code> or <code>plan-and-apply</code></p> | `false` | `""` |
@@ -120,7 +120,7 @@ jobs:
 
       - use: actions/setup-terraform@v3
         with:
-          terraform_version: 1.13.3
+          terraform_version: 1.15.7
 
       - name: Install dependencies
         run: yarn install
@@ -133,10 +133,10 @@ jobs:
         run: yarn test
 
       - name: Run Terraform CDK
-        uses: hashicorp/terraform-cdk-action@v11
+        uses: hashicorp/terraform-cdk-action@v2
         with:
           cdktfVersion: 0.21.0
-          terraformVersion: 1.13.3
+          terraformVersion: 1.15.7
           mode: plan-only
           stackName: my-stack
           terraformCloudToken: ${{ secrets.TF_API_TOKEN }}
@@ -172,7 +172,7 @@ jobs:
 
       - use: actions/setup-terraform@v3
         with:
-          terraform_version: 1.13.3
+          terraform_version: 1.15.7
 
       - name: Install dependencies
         run: yarn install
@@ -185,10 +185,10 @@ jobs:
         run: yarn test
 
       - name: Run Terraform CDK
-        uses: hashicorp/terraform-cdk-action@v11
+        uses: hashicorp/terraform-cdk-action@v2
         with:
           cdktfVersion: 0.21.0
-          terraformVersion: 1.13.3
+          terraformVersion: 1.15.7
           mode: auto-approve-apply
           stackName: my-stack
           terraformCloudToken: ${{ secrets.TF_API_TOKEN }}
@@ -220,7 +220,7 @@ jobs:
 
       - use: actions/setup-terraform@v3
         with:
-          terraform_version: 1.13.3
+          terraform_version: 1.15.7
 
       - name: Install dependencies
         run: yarn install
@@ -233,10 +233,10 @@ jobs:
         run: yarn test
 
       - name: Test the synth
-        uses: hashicorp/terraform-cdk-action@v11
+        uses: hashicorp/terraform-cdk-action@v2
         with:
           cdktfVersion: 0.21.0
-          terraformVersion: 1.13.3
+          terraformVersion: 1.15.7
           mode: synth-only
           stackName: my-stack
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
   terraformVersion:
     description: The version of Terraform to use
-    default: 1.13.3
+    default: 1.15.7
     required: false
   workingDirectory:
     description: The directory to use for the project


### PR DESCRIPTION
This PR increases the default version of Terraform used from `1.13.3` to version `1.15.7`.
This is considered a breaking change because anyone who does not manually specify a `terraformVersion` in their action configuration will automatically start using the new version.